### PR TITLE
UMBC #19 - Changed controller_input to Not Use a Smart Pointer

### DIFF
--- a/include/umbc/vcontroller.hpp
+++ b/include/umbc/vcontroller.hpp
@@ -28,7 +28,7 @@ class VController : public Controller {
 
 	std::uint16_t poll_rate_ms;
 	std::map<controller_digital_e_t, Digital> digitals;
-	std::unique_ptr<std::queue<ControllerInput>> controller_input;
+	std::queue<ControllerInput> controller_input;
 	std::unique_ptr<Task> t_update_controller_input;
 
 	/**


### PR DESCRIPTION
Changed controller_input, a member of the virtual controller class, to not use a smart pointer for a dynamically allocated queue object and use a queue object that is not dynamically allocated  instead.