### PR TITLE
refs #25 - Implement the Robot Selection Menu

### DIFF
--- a/include/umbc/robot.hpp
+++ b/include/umbc/robot.hpp
@@ -50,7 +50,7 @@ class Robot {
     /**
      * Menu to select the competition type using the LLEMU.
      * 
-     * @returns 1 if a selection was made, otherwise -1.
+     * @returns always 1
      */
     std::int32_t menu_competition();
 

--- a/include/umbc/robot.hpp
+++ b/include/umbc/robot.hpp
@@ -19,34 +19,33 @@ using namespace std;
 
 namespace umbc {
 typedef enum {
-    ALLIANCE_RED = 0,
-    ALLIANCE_BLUE = 1
-} alliance;
-
-typedef enum {
-    POSITION_ONE = 0,
-    POSITION_TWO = 1
-} position;
-
-typedef enum {
     COMPETITION_MATCH = 0,
     COMPETITION_SKILLS = 1
 } competition;
 
 typedef enum {
     MODE_COMPETITION = 0,
-    MODE_TRAIN_AUTONOMOUS = 1,
-    MODE_PRACTICE_AUTONOMOUS = 2,
-    MODE_PRACTICE_OPCONTROL = 3
+    MODE_TRAIN_AUTONOMOUS = 1
 } mode;
+
+typedef enum {
+    ALLIANCE_RED = 0,
+    ALLIANCE_BLUE = 1
+} alliance;
+
+typedef enum {
+    POSITION_ALPHA = 0,
+    POSITION_BRAVO = 1
+} position;
+
 
 class Robot {
     
     private:
-    std::int32_t mode;
-    std::int32_t competition;
-    std::int32_t alliance;
-    std::int32_t position;
+    umbc::competition competition;
+    umbc::mode mode;
+    umbc::alliance alliance;
+    umbc::position position;
 
     /**
      * Menu to select the mode using the LLEMU.

--- a/include/umbc/robot.hpp
+++ b/include/umbc/robot.hpp
@@ -38,6 +38,12 @@ typedef enum {
     POSITION_BRAVO = 1
 } position;
 
+typedef enum {
+    MENU_COMPETITION = 0,
+    MENU_MODE = 1,
+    MENU_ALLIANCE = 2,
+    MENU_POSITION = 3
+} sub_menu;
 
 class Robot {
     

--- a/include/umbc/robot.hpp
+++ b/include/umbc/robot.hpp
@@ -2,7 +2,7 @@
  * \file umbc/robot.hpp
  *
  * Contains the prototype for the Robot. The Robot holds various values used for
- * competition and practice, as well as holds the functions for the selection menu,
+ * different modes, as well as holds the functions for the selection menu,
  * autonomous, training autonomous, and opcontrol.
  */
 
@@ -48,22 +48,30 @@ class Robot {
     umbc::position position;
 
     /**
-     * Menu to select the mode using the LLEMU.
-     */
-    std::int32_t menu_mode();
-
-    /**
      * Menu to select the competition type using the LLEMU.
+     * 
+     * @returns 1 if a selection was made, otherwise -1.
      */
     std::int32_t menu_competition();
 
     /**
+     * Menu to select the mode using the LLEMU.
+     * 
+     * @returns 1 if a selection was made, otherwise -1.
+     */
+    std::int32_t menu_mode();
+
+    /**
      * Menu to select the alliance using the LLEMU.
+     * 
+     * @returns 1 if a selection was made, otherwise -1.
      */
     std::int32_t menu_alliance();
 
     /**
      * Menu to select the starting position using the LLEMU.
+     * 
+     * @returns 1 if a selection was made, otherwise -1.
      */
     std::int32_t menu_position();
 

--- a/src/umbc/robot.cpp
+++ b/src/umbc/robot.cpp
@@ -17,18 +17,141 @@ using namespace std;
 
 std::int32_t umbc::Robot::menu_competition() {
 
+    std::uint8_t btn_press = 0;
+
+    pros::lcd::clear();
+    pros::lcd::set_text(1, "Select Competition Mode");
+    pros::lcd::set_text(3, "1) Match");
+    pros::lcd::set_text(4, "2) Skills");
+
+    while(0 == btn_press) {
+
+        btn_press = pros::lcd::read_buttons();
+        
+        if (LCD_BTN_LEFT == btn_press) {
+            this->competition = COMPETITION_MATCH;
+        } else if (LCD_BTN_CENTER == btn_press) {
+            this->competition = COMPETITION_SKILLS;
+        } else {
+            btn_press = 0;
+        }
+
+        pros::Task::delay(10);
+    }
+
+    while (0 != pros::lcd::read_buttons()) {
+        pros::Task::delay(10);
+    }
+
+    pros::lcd::clear();
 }
 
 std::int32_t umbc::Robot::menu_mode() {
 
+    std::uint8_t menu_direction = 1;
+    std::uint8_t btn_press = 0;
+
+    pros::lcd::clear();
+    pros::lcd::set_text(1, "Select Mode");
+    pros::lcd::set_text(3, "1) Competition");
+    pros::lcd::set_text(4, "2) Train Autonomous");
+    pros::lcd::set_text(5, "3) Back");
+    
+    while(0 == btn_press) {
+
+        btn_press = pros::lcd::read_buttons();
+        
+        if (LCD_BTN_LEFT == btn_press) {
+            this->mode = MODE_COMPETITION;
+        } else if (LCD_BTN_CENTER == btn_press) {
+            this->mode = MODE_TRAIN_AUTONOMOUS;
+        } else if (LCD_BTN_RIGHT == btn_press) {
+            menu_direction = -1;
+        } else {
+            btn_press = 0;
+        }
+
+        pros::Task::delay(10);
+    }
+
+    while (0 != pros::lcd::read_buttons()) {
+        pros::Task::delay(10);
+    }
+
+    pros::lcd::clear();
+    return menu_direction;
 }
 
 std::int32_t umbc::Robot::menu_alliance() {
 
+    std::uint8_t menu_direction = 1;
+    std::uint8_t btn_press = 0;
+
+    pros::lcd::clear();
+    pros::lcd::set_text(1, "Select Alliance");
+    pros::lcd::set_text(3, "1) Red");
+    pros::lcd::set_text(4, "2) Blue");
+    pros::lcd::set_text(5, "3) Back");
+    
+    while(0 == btn_press) {
+
+        btn_press = pros::lcd::read_buttons();
+        
+        if (LCD_BTN_LEFT == btn_press) {
+            this->alliance = ALLIANCE_RED;
+        } else if (LCD_BTN_CENTER == btn_press) {
+            this->alliance = ALLIANCE_BLUE;
+        } else if (LCD_BTN_RIGHT == btn_press) {
+            menu_direction = -1;
+        } else {
+            btn_press = 0;
+        }
+
+        pros::Task::delay(10);
+    }
+
+    while (0 != pros::lcd::read_buttons()) {
+        pros::Task::delay(10);
+    }
+
+    pros::lcd::clear();
+    return menu_direction;
 }
 
 std::int32_t umbc::Robot::menu_position() {
 
+    std::uint8_t menu_direction = 1;
+    std::uint8_t btn_press = 0;
+
+    pros::lcd::clear();
+    pros::lcd::set_text(1, "Select Starting Position");
+    pros::lcd::set_text(3, "1) Alpha");
+    pros::lcd::set_text(4, "2) Bravo");
+    pros::lcd::set_text(5, "3) Back");
+    
+    while(0 == btn_press) {
+
+        btn_press = pros::lcd::read_buttons();
+        
+        if (LCD_BTN_LEFT == btn_press) {
+            this->position = POSITION_ALPHA;
+        } else if (LCD_BTN_CENTER == btn_press) {
+            this->position = POSITION_BRAVO;
+        } else if (LCD_BTN_RIGHT == btn_press) {
+            menu_direction = -1;
+        } else {
+            btn_press = 0;
+        }
+
+        pros::Task::delay(10);
+    }
+
+    while (0 != pros::lcd::read_buttons()) {
+        pros::Task::delay(10);
+    }
+
+    pros::lcd::clear();
+    return menu_direction;
 }
 
 void umbc::Robot::menu() {

--- a/src/umbc/robot.cpp
+++ b/src/umbc/robot.cpp
@@ -1,0 +1,48 @@
+/**
+ * \file umbc/robot.cpp
+ *
+ * Contains the implementation for the Robot. The Robot holds various values used for
+ * different modes, as well as holds the functions for the selection menu,
+ * autonomous, training autonomous, and opcontrol.
+ */
+
+#include "api.h"
+#include "umbc.h"
+
+#include <cstdint>
+
+using namespace pros;
+using namespace umbc;
+using namespace std;
+
+std::int32_t umbc::Robot::menu_competition() {
+
+}
+
+std::int32_t umbc::Robot::menu_mode() {
+
+}
+
+std::int32_t umbc::Robot::menu_alliance() {
+
+}
+
+std::int32_t umbc::Robot::menu_position() {
+
+}
+
+void umbc::Robot::menu() {
+
+}
+
+void umbc::Robot::autonomous() {
+
+}
+
+void umbc::Robot::opcontrol() {
+
+}
+
+void umbc::Robot::train_autonomous() {
+
+}

--- a/src/umbc/robot.cpp
+++ b/src/umbc/robot.cpp
@@ -156,6 +156,38 @@ std::int32_t umbc::Robot::menu_position() {
 
 void umbc::Robot::menu() {
 
+    const uint8_t last_sub_menu = MENU_POSITION;
+    uint8_t current_sub_menu = MENU_COMPETITION;
+
+    if (!pros::lcd::is_initialized()) {
+        return;
+    }
+
+    pros::lcd::clear();
+
+    while (MENU_POSITION >= current_sub_menu) {
+
+        switch (current_sub_menu) {
+            case MENU_COMPETITION:
+                current_sub_menu += menu_competition();
+            break;
+            case MENU_MODE:
+                current_sub_menu += menu_mode();
+            break;
+            case MENU_ALLIANCE:
+                current_sub_menu += menu_alliance();
+            break;
+            case MENU_POSITION:
+                current_sub_menu += menu_position();
+            default:
+                break;
+        }
+    }
+
+    pros::lcd::clear();
+    pros::lcd::set_text(1, "Selection Complete");
+    pros::Task::delay(3000);
+    pros::lcd::clear();
 }
 
 void umbc::Robot::autonomous() {


### PR DESCRIPTION
Implemented the robot selection menu using the Legacy LCD Emulator. The menu is able to select the alliance color (red or blue), starting position (alpha or bravo), competition type (match or skills), and mode (competition or train). The menu also allows the user to go backwards in case a mistake was made.