### PR TITLE
UMBC #63 - Moved Setting Physical Controllers in opcontrol

### DIFF
--- a/include/umbc.h
+++ b/include/umbc.h
@@ -1,6 +1,8 @@
 #ifndef _UMBC_H_
 #define _UMBC_H_
 
+#define MSG_DELAY_MS 3000
+
 #ifdef __cplusplus
 #include "umbc/controllerinput.hpp"
 #include "umbc/controllerrecorder.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,30 +107,35 @@ void autonomous() {
  */
 void opcontrol() {
 
-	pros::lcd::clear();
-	
-	if (MODE_TRAIN_AUTONOMOUS == robot.get_mode()) {
-		INFO("autonomous training starting...");
-		if (usd::is_installed()) {
-			pros::lcd::set_text(1, "Autonomous Training Active");
-			robot.train_autonomous(PARTNER_CONTROLLER);
-			pros::lcd::clear();
-    		pros::lcd::set_text(1, "Autonomous Training Complete");
-    		INFO("autonomous training complete");
-			delay(3000);
-			initialize();
-		} else {
-			pros::lcd::set_text(1, "No SD Card Detected");
-			ERROR("autonomous training failed; no SD Card detected");
-		}
-	} else {
-		pros::lcd::set_text(1, "Opcontrol Active");
-		INFO("opcontrol active");
+	while (1) {
+		pros::lcd::clear();
+
+		INFO("setting robot controllers to physical controllers...");
 		robot.set_controller_master(pros::Controller(E_CONTROLLER_MASTER));
 		robot.set_controller_partner(pros::Controller(E_CONTROLLER_PARTNER));
-		robot.opcontrol(robot.get_controller_master(), robot.get_controller_partner());
-	}
+		INFO("robot controllers set to physical controllers");
 
-	while (1);
-	pros::lcd::clear();
+		if (MODE_TRAIN_AUTONOMOUS == robot.get_mode()) {
+			INFO("autonomous training starting...");
+			if (usd::is_installed()) {
+				pros::lcd::set_text(1, "Autonomous Training Active");
+				robot.train_autonomous(PARTNER_CONTROLLER);
+				pros::lcd::clear();
+    			pros::lcd::set_text(1, "Autonomous Training Complete");
+    			INFO("autonomous training complete");
+				pros::Task::delay(MSG_DELAY_MS);
+				initialize();
+			} else {
+				pros::lcd::set_text(1, "No SD Card Detected");
+				ERROR("autonomous training failed; no SD Card detected");
+				INFO("aborting program in " << MSG_DELAY_MS << " ms...");
+				pros::Task::delay(MSG_DELAY_MS);
+				abort();
+			}
+		} else {
+			pros::lcd::set_text(1, "Opcontrol Active");
+			INFO("opcontrol active");
+			robot.opcontrol(robot.get_controller_master(), robot.get_controller_partner());
+		}
+	}
 }

--- a/src/umbc/robot.cpp
+++ b/src/umbc/robot.cpp
@@ -150,7 +150,7 @@ void umbc::Robot::menu() {
 
     pros::lcd::clear();
     pros::lcd::set_text(1, "Selection Complete");
-    pros::Task::delay(3000);
+    pros::Task::delay(MSG_DELAY_MS);
     pros::lcd::clear();
     INFO("menu selections completed");
 }


### PR DESCRIPTION
Moved setting physical controllers in opcontrol so they are always set no matter the mode selected. Fixed bug for when re-initializing after training autonomous. Program now aborts if no SD card is installed when training an autonomous.