### PR TITLE
UMBC #71 - Robot.robot_opcontrol Function Parameter Fixed to Type Robot Pointer

### DIFF
--- a/include/umbc/robot.hpp
+++ b/include/umbc/robot.hpp
@@ -68,6 +68,10 @@ class Robot {
     /**
      * Allows operator to manually control the robot via a controller. Used
      * for training autonomous.
+     * 
+     * @param robot
+     *          The type for this parameter must be Robot*.
+     *          Intended to be 'this' pointer.
      */
     static void robot_opcontrol(Robot robot);
 

--- a/src/umbc/robot.cpp
+++ b/src/umbc/robot.cpp
@@ -155,9 +155,8 @@ void umbc::Robot::menu() {
     INFO("menu selections completed");
 }
 
-void umbc::Robot::robot_opcontrol(Robot robot) {
-
-    robot.opcontrol(robot.get_controller_master(), robot.get_controller_partner());
+void umbc::Robot::robot_opcontrol(Robot* robot) {
+    robot->opcontrol(robot->get_controller_master(), robot->get_controller_partner());
 }
 
 void umbc::Robot::autonomous(uint32_t include_partner_controller) {


### PR DESCRIPTION
 Fixed Robot.robot_opcontrol to have an input parameter of type Robot*.